### PR TITLE
Fix mypy issues across seedlayer

### DIFF
--- a/example/dataseed.py
+++ b/example/dataseed.py
@@ -6,6 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from seedlayer import SeedLayer
+from seedlayer.types import SeedPlan
 
 from .models import Base, Category, Customer, Order, OrderItem, Product
 
@@ -16,7 +17,7 @@ Base.metadata.create_all(engine)
 
 
 class CustomCommerceProvider(BaseProvider):
-    def product_name(self):
+    def product_name(self) -> str:
         adjectives = ["Awesome", "Practical", "Sleek", "Amazing", "Ergonomic", "Gorgeous", "Gold"]
         sizes = ["Little", "Small", "Medium", "Regular", "Large", "Big", "Extra Large", "Jumbo"]
         colors = ["Red", "Blue", "Green", "Yellow", "White", "Silver"]
@@ -32,7 +33,7 @@ class CustomCommerceProvider(BaseProvider):
 
 
 # Define seed plan:
-seed_plan = {
+seed_plan: SeedPlan = {
     Category: 700,
     Product: 700,
     Customer: 700,

--- a/src/seedlayer/constants.py
+++ b/src/seedlayer/constants.py
@@ -1,14 +1,11 @@
-from typing import (
-    Any,
-    Dict,
-)
+from typing import Any, Dict
 
 from sqlalchemy import UUID, Boolean, DateTime, Float, Integer, String, Text
 from sqlalchemy.types import TypeEngine
 
 from .seed import Seed
 
-TypeDefaults = Dict[TypeEngine[Any], str | Seed]
+TypeDefaults = Dict[type[TypeEngine[Any]], str | Seed]
 
 TYPE_DEFAULTS: TypeDefaults = {
     Integer: Seed(faker_provider="random_int", faker_kwargs={"min": 0, "max": 1000000}),

--- a/src/seedlayer/primary_keys.py
+++ b/src/seedlayer/primary_keys.py
@@ -1,61 +1,58 @@
 import random
-from collections import namedtuple
-from collections.abc import Hashable
-from typing import (
-    Dict,
-    Generic,
-    Iterable,
-    Iterator,
-    Set,
-)
+from collections.abc import Hashable, Iterable, Iterator
+from typing import Dict, Generic
 
-from .types import PK, Primary_Key_names
+from .types import PK
 
 
 class PrimaryKeys(Generic[PK]):
-    def __init__(self, pk_names: Primary_Key_names) -> None:
-        if not pk_names:
-            raise ValueError("Primary key names cannot be empty")
-        pk_names = tuple(pk_names)  # Ensure immutable
-        if len(set(pk_names)) != len(pk_names):
-            raise ValueError("Primary key names must be unique")
-        self._names = pk_names
-        self._pks: Set["PrimaryKeys._pk_type"] = set()
-        self._pk_type = namedtuple("PrimaryPK", pk_names)
+    """Track unique primary key values for a model."""
 
-    def _to_tuple(self, pk: Iterable[PK]) -> "PrimaryKeys._pk_type":
-        try:
-            tpl = self._pk_type(*pk)
-        except TypeError as e:
-            raise ValueError(f"Expected {len(self._names)} fields, got {len(pk)}") from e
-        if not all(isinstance(x, Hashable) for x in tpl):
-            raise TypeError(f"All components must be hashable: {tpl}")
-        return tpl
+    def __init__(self, pk_names: Iterable[str]) -> None:
+        names = tuple(pk_names)
+        if not names:
+            raise ValueError("Primary key names cannot be empty")
+        if len(set(names)) != len(names):
+            raise ValueError("Primary key names must be unique")
+        self._names: tuple[str, ...] = names
+        self._pks: set[tuple[PK, ...]] = set()
+
+    def _validate(self, pk: Iterable[PK]) -> tuple[PK, ...]:
+        values = tuple(pk)
+        expected = len(self._names)
+        if len(values) != expected:
+            raise ValueError(f"Expected {expected} fields, got {len(values)}")
+        if not all(isinstance(value, Hashable) for value in values):
+            raise TypeError(f"All components must be hashable: {values}")
+        return values
 
     def add(self, pk: Iterable[PK]) -> None:
-        tpl = self._to_tuple(pk)
-        if tpl in self._pks:
-            raise ValueError(f"Duplicate primary key: {tpl}")
-        self._pks.add(tpl)
+        values = self._validate(pk)
+        if values in self._pks:
+            raise ValueError(f"Duplicate primary key: {values}")
+        self._pks.add(values)
 
-    def __iter__(self) -> Iterator["PrimaryKeys._pk_type"]:
+    def __iter__(self) -> Iterator[tuple[PK, ...]]:
         return iter(self._pks)
+
+    def _as_mapping(self, pk: tuple[PK, ...]) -> Dict[str, PK]:
+        return dict(zip(self._names, pk, strict=True))
 
     def dicts(self) -> Iterator[Dict[str, PK]]:
         for pk in self._pks:
-            yield dict(zip(self._names, pk, strict=False))
+            yield self._as_mapping(pk)
 
-    def get_random(self):
-        """Return a random primary key from the set."""
-        if not self._pks or len(self._pks) < 1:
+    def get_random(self) -> Dict[str, PK]:
+        """Return a random primary key as a mapping of column name to value."""
+        if not self._pks:
             raise ValueError("No primary keys available")
-        return random.choice(list(self._pks))
+        return self._as_mapping(random.choice(tuple(self._pks)))
 
     def __len__(self) -> int:
         return len(self._pks)
 
     def __contains__(self, pk: Iterable[PK]) -> bool:
         try:
-            return self._to_tuple(pk) in self._pks
+            return self._validate(pk) in self._pks
         except (ValueError, TypeError):
             return False

--- a/src/seedlayer/seed.py
+++ b/src/seedlayer/seed.py
@@ -1,14 +1,6 @@
 import enum
 import inspect
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Mapping,
-    Sequence,
-    Set,
-    Tuple,
-)
+from typing import Any, Callable, Dict, Mapping, Sequence, Set, Tuple
 
 from faker import Faker
 
@@ -33,14 +25,14 @@ class Seed:
         self,
         faker_provider: str,
         faker_args: FakerArgs = (),
-        faker_kwargs: FakerKwargs = None,
-    ):
+        faker_kwargs: FakerKwargs | None = None,
+    ) -> None:
         if faker_kwargs is None:
             faker_kwargs = {}
         self.provider = faker_provider
         self.dependencies: Set[str] = set()  # Track ColumnReference column names
         self.faker_args = faker_args
-        self.faker_kwargs = faker_kwargs
+        self.faker_kwargs: FakerKwargs = faker_kwargs
 
         # Collect dependencies from ColumnReference instances in args and kwargs
         for arg in faker_args:

--- a/src/seedlayer/seeded_column.py
+++ b/src/seedlayer/seeded_column.py
@@ -1,24 +1,37 @@
-from typing import (
-    Any,
-    Set,
-)
+from typing import Any, TYPE_CHECKING, Set
 
 from faker import Faker
 from sqlalchemy import Column
+from sqlalchemy.sql.type_api import TypeEngine
 
 from .seed import Seed
+from .types import SeededColumnContext
+
+if TYPE_CHECKING:
+    from sqlalchemy import Column as SQLAlchemyColumn
+    ColumnBase = SQLAlchemyColumn[Any]
+else:  # pragma: no cover - runtime behaviour only
+    ColumnBase = Column
 
 
 class SeededColumnMixin:
     """Adds `seed` and `generate()` behaviour."""
 
+    seed: Seed | None
+    nullable: bool | None
+    name: str
+    type: TypeEngine[Any]
+    primary_key: bool
+    autoincrement: Any
+    server_default: Any
+
     def __init__(
         self,
-        *args,
+        *args: Any,
         seed: Seed | str | None = None,
         nullable_chance: int = 20,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         # Allow    Integer   → Integer()
         if args and isinstance(args[0], type):
             args = (args[0](), *args[1:])
@@ -38,11 +51,14 @@ class SeededColumnMixin:
     def generate(
         self,
         faker: Faker,
-        column_context: dict | None = None,
+        column_context: SeededColumnContext | None = None,
         used_unique_values: Set[Any] | None = None,
-    ):
+    ) -> Any | None:
         if self.nullable and faker.random_int(min=1, max=100) <= self.nullable_chance:
             return None
+
+        if self.seed is None:
+            raise ValueError("SeededColumn requires a Seed to generate values")
 
         return self.seed.generate(
             column_context=column_context,
@@ -61,5 +77,5 @@ class SeededColumnMixin:
 
 
 # Custom Column class
-class SeededColumn(SeededColumnMixin, Column):
+class SeededColumn(SeededColumnMixin, ColumnBase):
     inherit_cache = True  # 🚀 enable SQL compilation caching

--- a/src/seedlayer/seeded_model.py
+++ b/src/seedlayer/seeded_model.py
@@ -1,22 +1,16 @@
-from collections import namedtuple
+from collections.abc import Iterable, Mapping
 from itertools import islice, product
 from random import shuffle
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    NamedTuple,
-    Self,
-    Set,
-)
+from typing import Any, Dict, Set, cast
 
 from faker import Faker
 from sqlalchemy import Column
-from sqlalchemy.orm import DeclarativeBase, Session
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.schema import Table
 
 from .constants import TYPE_DEFAULTS, TypeDefaults
 from .dependency_graph import DependencyGraph
-from .primary_keys import PK, PrimaryKeys
+from .primary_keys import PrimaryKeys
 from .seed import Seed
 from .seeded_column import SeededColumnMixin
 from .types import SeedPlan, UniqueValues
@@ -25,27 +19,34 @@ from .types import SeedPlan, UniqueValues
 class SeededModel:
     def __init__(
         self,
-        model: DeclarativeBase,
+        model: type[Any],
         nb_of_rows_to_seed: int,
         session: Session,
         seed_plan: SeedPlan,
     ) -> None:
         self.is_link_table = False
-        self.table = model.__table__
-        self.base_model = model
+        table = getattr(model, "__table__", None)
+        if table is None:
+            raise ValueError(f"Model {model.__name__} has no __table__ attribute")
+        self.table = cast(Table, table)
+        self.base_model: type[Any] = model
         self.nb_of_rows_to_seed = nb_of_rows_to_seed
         self.name = model.__name__
         self.foreign_key_dependencies: Set[str] = set()
-        self.columns = {col.name: col for col in self.table.columns}
-        self.primary_keys = [col.name for col in self.table.primary_key.columns]
-        self.unique_columns = [col.name for col in self.table.columns if col.unique]
-        self.existing_ids = PrimaryKeys[PK](self.primary_keys)
-        self.new_ids = PrimaryKeys[PK](self.primary_keys)
+        self.columns: Dict[str, Column[Any]] = {col.name: col for col in self.table.columns}
+        self.primary_keys: tuple[str, ...] = tuple(
+            col.name for col in self.table.primary_key.columns
+        )
+        self.unique_columns: tuple[str, ...] = tuple(
+            col.name for col in self.table.columns if col.unique
+        )
+        self.existing_ids: PrimaryKeys[Any] = PrimaryKeys(self.primary_keys)
+        self.new_ids: PrimaryKeys[Any] = PrimaryKeys(self.primary_keys)
 
         dependency_graph = DependencyGraph()
-        primary_foreign_keys = []
+        primary_foreign_keys: list[str] = []
 
-        for column in model.__table__.columns:
+        for column in self.table.columns:
             if column.primary_key and column.foreign_keys:
                 primary_foreign_keys.append(column.name)
 
@@ -98,7 +99,7 @@ class SeededModel:
         id_target = self.new_ids if new_data else self.existing_ids
         for row in query:
             # Extract primary key values from model instances or Row objects
-            pk_values = []
+            pk_values: list[Any] = []
             for name in self.primary_keys:
                 # Try getattr for model instances, then _mapping for Row objects
                 value = getattr(row, name, None)
@@ -108,8 +109,8 @@ class SeededModel:
                     raise ValueError(f"Missing primary key field '{name}' in row: {row}")
                 pk_values.append(value)
 
-            pk_values = tuple(pk_values)
-            id_target.add(pk_values)
+            pk_tuple = tuple(pk_values)
+            id_target.add(pk_tuple)
 
             # Handle unique columns
             for col_name in self.unique_columns:
@@ -119,7 +120,9 @@ class SeededModel:
                 if value is not None:
                     self.unique_values[col_name].add(value)
 
-    def get_fk_combinations(self, models: Dict[str, "SeededModel"], n: int) -> list[NamedTuple]:
+    def get_fk_combinations(
+        self, models: Mapping[str, "SeededModel"], n: int
+    ) -> list[Dict[str, Any]]:
         """Return up to *n* deterministic FK‐value combinations.
 
         * Correct mapping: field order is driven by ``fk_targets``.
@@ -154,7 +157,7 @@ class SeededModel:
             if not pk_data:
                 raise ValueError(f"No new IDs for FK '{col.name}' -> '{target_table.name}'")
 
-            ids = [getattr(pk, target_field) for pk in pk_data]
+            ids = [pk[target_field] for pk in pk_data.dicts()]
             if not ids:
                 raise ValueError(f"No '{target_field}' values found in '{target_table.name}'")
 
@@ -169,18 +172,19 @@ class SeededModel:
             raise ValueError(f"Requested {n} combos, but only {max_combos} possible.")
 
         # ── 3. Build the iterator and slice lazily ─────────────────────────────────
-        FKCombination = namedtuple("FKCombination", fk_targets)
-        combo_iter = (FKCombination(*combo) for combo in product(*value_lists))
+        combo_iter = (
+            dict(zip(fk_targets, combo, strict=True)) for combo in product(*value_lists)
+        )
 
         return list(islice(combo_iter, n))
 
     def table_to_model(
         self,
-        column: Column,
-        table: Any,  # Table type from SQLAlchemy, or use Table if imported
-        models: Dict[str, "SeededModel"],
+        column: Any,
+        table: Table,
+        models: Mapping[str, "SeededModel"],
     ) -> "SeededModel":
-        target_model: "SeededModel" = None
+        target_model: "SeededModel" | None = None
         for model in models.values():
             if model.table == table:
                 target_model = model
@@ -194,11 +198,11 @@ class SeededModel:
     def fake_column(
         self,
         col_name: str,
-        models: Dict[str, "SeededModel"],
+        models: Mapping[str, "SeededModel"],
         faker: Faker,
         type_defaults: TypeDefaults,
         column_context: Dict[str, Any],
-        pfk_combo: Any = None,  # NamedTuple or None
+        pfk_combo: Mapping[str, Any] | None = None,
     ) -> Any:
         column = self.columns[col_name]
 
@@ -209,19 +213,17 @@ class SeededModel:
         # Handle Primary keys that are also foreign keys, must use valid combination
         if column.foreign_keys and column.primary_key:
             if pfk_combo is None:
-                raise (
-                    f"No combination of foreign key profided for \
-                    column {column} in model {self.name}"
+                raise ValueError(
+                    f"No combination of foreign keys provided for column {column} "
+                    f"in model {self.name}"
                 )
 
-            if col_name not in pfk_combo._fields:
+            if col_name not in pfk_combo:
                 raise ValueError(
                     f"Field '{col_name}' not found in primary key combination : {pfk_combo}"
                 )
 
-            # fk = next(iter(column.foreign_keys))
-            # target_table = fk.column.table
-            return getattr(pfk_combo, col_name)
+            return pfk_combo[col_name]
 
         if column.foreign_keys:
             # For now: assume single FK per column
@@ -230,9 +232,9 @@ class SeededModel:
             target_model = self.table_to_model(column, target_table, models)
 
             # Pick random ID from models and extract the scalar value
-            pk_tuple = models[target_model.name].new_ids.get_random()
+            pk_mapping = models[target_model.name].new_ids.get_random()
             target_field = fk.column.name  # The referenced column name (e.g., 'id')
-            return getattr(pk_tuple, target_field)  # Extract the scalar value
+            return pk_mapping[target_field]
 
             # Pick random ID from models
             # return models[target_model.name].new_ids.get_random()
@@ -260,8 +262,11 @@ class SeededModel:
                     used_unique_values=used_unique_values,
                 )
 
-        if column.default:
-            return column.default.arg()
+        if column.default is not None:
+            default_arg = getattr(column.default, "arg", None)
+            if callable(default_arg):
+                return default_arg()
+            return default_arg
 
         if column.server_default:
             return None
@@ -276,13 +281,13 @@ class SeededModel:
 
     def fake_row(
         self,
-        models: Dict[str, Self],
+        models: Mapping[str, "SeededModel"],
         faker: Faker,
         type_defaults: TypeDefaults,
-        pfk_combo: NamedTuple = None,
-    ):
-        column_context = {}
-        row = {}
+        pfk_combo: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        column_context: Dict[str, Any] = {}
+        row: Dict[str, Any] = {}
 
         for col_name in self.columns_seed_order:
             value = self.fake_column(
@@ -300,7 +305,13 @@ class SeededModel:
 
         return row
 
-    def fake_rows(self, n: int, models: Dict[str, Self], faker: Faker, type_defaults: TypeDefaults):
+    def fake_rows(
+        self,
+        n: int,
+        models: Mapping[str, "SeededModel"],
+        faker: Faker,
+        type_defaults: TypeDefaults,
+    ) -> list[Dict[str, Any]]:
         if self.is_link_table:
             pfk_possible_combinations = self.get_fk_combinations(models, n)
 

--- a/src/seedlayer/seedlayer.py
+++ b/src/seedlayer/seedlayer.py
@@ -1,9 +1,6 @@
 import logging
 from pprint import pformat
-from typing import (
-    Dict,
-    Optional,
-)
+from typing import Dict, Optional
 
 from faker import Faker
 from sqlalchemy.orm import Session
@@ -111,3 +108,6 @@ class SeedLayer:
                 for name, model in self.models.items()
             }
         )
+
+
+__all__ = ["SeedLayer", "SeededModel"]

--- a/src/seedlayer/types.py
+++ b/src/seedlayer/types.py
@@ -1,14 +1,10 @@
-from collections import namedtuple
 from collections.abc import Hashable
-from typing import Any, Dict, Set, Tuple, TypeVar
-
-from sqlalchemy.orm import DeclarativeBase
+from typing import Any, Dict, Mapping, Set, TypeVar
 
 SeededColumnContext = Dict[str, Any]
 
-SeedPlan = Dict[DeclarativeBase, int]
+SeedPlan = Mapping[type[Any], int]
 
 PK = TypeVar("PK", bound=Hashable)
-Primary_Key = namedtuple
-Primary_Key_names = Tuple[str]
+Primary_Key_names = tuple[str, ...]
 UniqueValues = Dict[str, Set[Hashable]]

--- a/tests/unit/dependency_graph_test.py
+++ b/tests/unit/dependency_graph_test.py
@@ -4,44 +4,44 @@ from seedlayer.dependency_graph import DependencyGraph
 
 
 @pytest.fixture
-def graph():
+def graph() -> DependencyGraph:
     """Set up a fresh DependencyGraph instance for each test."""
     return DependencyGraph()
 
 
-def test_add_node_no_dependencies(graph):
+def test_add_node_no_dependencies(graph: DependencyGraph) -> None:
     """Test adding a node with no dependencies."""
     graph.add("A")
     assert graph._graph == {"A": set()}
 
 
-def test_add_node_with_dependencies(graph):
+def test_add_node_with_dependencies(graph: DependencyGraph) -> None:
     """Test adding a node with dependencies."""
     graph.add("A", {"B", "C"})
     assert graph._graph == {"A": {"B", "C"}}
 
 
-def test_add_same_node_multiple_times(graph):
+def test_add_same_node_multiple_times(graph: DependencyGraph) -> None:
     """Test adding the same node multiple times updates dependencies."""
     graph.add("A", {"B"})
     graph.add("A", {"C"})
     assert graph._graph == {"A": {"B", "C"}}
 
 
-def test_topological_sort_empty_graph(graph):
+def test_topological_sort_empty_graph(graph: DependencyGraph) -> None:
     """Test topological sort on an empty graph."""
     result = graph.topological_sort()
     assert result == []
 
 
-def test_topological_sort_single_node(graph):
+def test_topological_sort_single_node(graph: DependencyGraph) -> None:
     """Test topological sort with a single node."""
     graph.add("A")
     result = graph.topological_sort()
     assert result == ["A"]
 
 
-def test_topological_sort_linear_graph(graph):
+def test_topological_sort_linear_graph(graph: DependencyGraph) -> None:
     """Test topological sort on a linear graph (A -> B -> C)."""
     graph.add("A", {"B"})
     graph.add("B", {"C"})
@@ -50,7 +50,7 @@ def test_topological_sort_linear_graph(graph):
     assert result == ["C", "B", "A"]
 
 
-def test_topological_sort_tree_graph(graph):
+def test_topological_sort_tree_graph(graph: DependencyGraph) -> None:
     """Test topological sort on a tree-like graph (A -> {B, C})."""
     graph.add("A", {"B", "C"})
     graph.add("B")
@@ -61,7 +61,7 @@ def test_topological_sort_tree_graph(graph):
     assert set(result[:2]) == {"B", "C"}
 
 
-def test_topological_sort_disconnected_components(graph):
+def test_topological_sort_disconnected_components(graph: DependencyGraph) -> None:
     """Test topological sort with disconnected components."""
     graph.add("A", {"B"})
     graph.add("B")
@@ -73,7 +73,7 @@ def test_topological_sort_disconnected_components(graph):
     assert result.index("D") < result.index("C")
 
 
-def test_topological_sort_dependency_only_node(graph):
+def test_topological_sort_dependency_only_node(graph: DependencyGraph) -> None:
     """Test topological sort when a node only appears as a dependency."""
     graph.add("A", {"B"})  # B is a dependency but not a key
     result = graph.topological_sort()
@@ -81,7 +81,7 @@ def test_topological_sort_dependency_only_node(graph):
     assert result.index("B") < result.index("A")
 
 
-def test_topological_sort_direct_cycle(graph):
+def test_topological_sort_direct_cycle(graph: DependencyGraph) -> None:
     """Test topological sort with a direct cycle (A -> B -> A)."""
     graph.add("A", {"B"})
     graph.add("B", {"A"})
@@ -89,7 +89,7 @@ def test_topological_sort_direct_cycle(graph):
         graph.topological_sort()
 
 
-def test_topological_sort_indirect_cycle(graph):
+def test_topological_sort_indirect_cycle(graph: DependencyGraph) -> None:
     """Test topological sort with an indirect cycle (A -> B -> C -> A)."""
     graph.add("A", {"B"})
     graph.add("B", {"C"})
@@ -98,7 +98,7 @@ def test_topological_sort_indirect_cycle(graph):
         graph.topological_sort()
 
 
-def test_topological_sort_complex_graph(graph):
+def test_topological_sort_complex_graph(graph: DependencyGraph) -> None:
     """Test topological sort on a complex graph with multiple dependencies."""
     graph.add("A", {"B", "C"})
     graph.add("B", {"D"})


### PR DESCRIPTION
## Summary
- replace dynamic namedtuple-based primary key tracking with typed tuple/mapping helpers and relax common type aliases
- tighten seed generation and seeded column/model orchestration with explicit annotations, FK combination dictionaries, and exported SeedLayer symbols
- repair the example package layout and annotate demo/tests so mypy can discover modules and typed fixtures

## Testing
- `uv run mypy`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8d12a30708330b512d9411a9e8fed